### PR TITLE
Draft: Added export to type `Theme<T>`.

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -1,4 +1,4 @@
-type Theme<T> = {
+export type Theme<T> = {
   render: (resume: object) => T | Promise<T>
 }
 


### PR DESCRIPTION
Hi,

I would like to to use function `render`, but I can not typehint the `theme` argument in render.
That's why I added the export.

Best regards
Enough7