### PR TITLE
feat(resume): support JSON comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@jsonresume/schema": "^1.0.0",
-        "json5": "^2.2.3",
         "sade": "^1.7.0",
+        "strip-json-comments": "^5.0.1",
         "yoctocolors": "^2.0.0"
       },
       "bin": {
@@ -1123,6 +1123,19 @@
       "dependencies": {
         "resolve": "~1.22.1",
         "strip-json-comments": "~3.1.1"
+      }
+    },
+    "node_modules/@rushstack/rig-package/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@rushstack/terminal": {
@@ -2579,18 +2592,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -3808,13 +3809,12 @@
       }
     },
     "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.1.tgz",
+      "integrity": "sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@jsonresume/schema": "^1.0.0",
+        "json5": "^2.2.3",
         "sade": "^1.7.0",
         "yoctocolors": "^2.0.0"
       },
@@ -2577,6 +2578,18 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@jsonresume/schema": "^1.0.0",
+    "json5": "^2.2.3",
     "sade": "^1.7.0",
     "yoctocolors": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "types": "./dist/index.d.ts",
@@ -50,8 +50,8 @@
   },
   "dependencies": {
     "@jsonresume/schema": "^1.0.0",
-    "json5": "^2.2.3",
     "sade": "^1.7.0",
+    "strip-json-comments": "^5.0.1",
     "yoctocolors": "^2.0.0"
   },
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+import json5 from 'json5'
 import { readFile, writeFile } from 'node:fs/promises'
 import sade from 'sade'
 import { red, yellow } from 'yoctocolors'
@@ -28,7 +29,7 @@ cli
       filename: string = 'resume.json',
       { output, theme }: RenderOptions,
     ) => {
-      const resume = JSON.parse(await readFile(filename, 'utf-8'))
+      const resume = json5.parse(await readFile(filename, 'utf-8'))
 
       const themeName = theme ?? resume?.meta?.theme
       if (!themeName) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
-import json5 from 'json5'
 import { readFile, writeFile } from 'node:fs/promises'
 import sade from 'sade'
+import stripJsonComments from 'strip-json-comments'
 import { red, yellow } from 'yoctocolors'
 import { init, render, validate } from './index.js'
 
@@ -29,7 +29,9 @@ cli
       filename: string = 'resume.json',
       { output, theme }: RenderOptions,
     ) => {
-      const resume = json5.parse(await readFile(filename, 'utf-8'))
+      const resume = JSON.parse(
+        stripJsonComments(await readFile(filename, 'utf-8')),
+      )
 
       const themeName = theme ?? resume?.meta?.theme
       if (!themeName) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -68,6 +68,23 @@ describe('render', () => {
     )
   })
 
+  it('renders a resume with comments ', async () => {
+    const resume = `//Template\n{"basics":{"name":"Benny"}}`
+
+    vi.mocked(readFile).mockResolvedValueOnce(resume)
+    vi.mocked(render).mockResolvedValueOnce('rendered')
+
+    await cli.parse(['', '', 'render', '--theme', 'jsonresume-theme-even'])
+
+    expect(readFile).toHaveBeenCalledTimes(1)
+    expect(readFile).toHaveBeenCalledWith('resume.json', 'utf-8')
+
+    expect(render).toHaveBeenCalledTimes(1)
+
+    expect(writeFile).toHaveBeenCalledTimes(1)
+    expect(writeFile).toHaveBeenCalledWith('resume.html', 'rendered')
+  })
+
   it('renders a resume with custom filename', async () => {
     const resume = {}
 


### PR DESCRIPTION
To make `resumed` the most convenient resume builder for developers, I implemented support for comments in JSON! 💫

**Use-Case:**

There are certain properties in my CV that I prefer not to render, so I occasionally comment out less important details. For example:

```json5
        {
            "highlights": [
                "Millions of sites use the CDN in production",
                "Larger market share than Yahoo's, Microsoft's and Google's javascript content distribution networks",
                "We serve hundreds of billions request a month",
                "Contains over 3000 popular Javascript libraries",
                "Millions of developers visit the site per year"
            ],
            "description": "Following Google's CDN for jQuery, we decided to start a CDN for the less popular Javascript frameworks. The CDN is community moderated and open source on GitHub. We secured a partnership with Cloudflare who now supports the infrastructure.",
            "website": "http://www.cdnjs.com",
            "name": "Cdnjs",
            "startDate": "2011-01-08"
        }
    ],
    // "languages": [
    //     {
    //         "language": "English",
    //         "fluency": "Native speaker"
    //     }
    // ],
``` 

Without my PR, this would break the rendering process:

> SyntaxError: Expected double-quoted property name in JSON 
> at JSON.parse

Using JSON5, we can support JSON that has comments inside. It may also be useful for people who just want to add comments to specific sections.